### PR TITLE
fix(MajaMobile.Android): support x64 and set TargetFrameworkVersion t…

### DIFF
--- a/MajaMobile/MajaMobile/MajaMobile.Android/MajaMobile.Android.csproj
+++ b/MajaMobile/MajaMobile/MajaMobile.Android/MajaMobile.Android.csproj
@@ -16,7 +16,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
@@ -41,6 +41,7 @@
     <AndroidManagedSymbols>true</AndroidManagedSymbols>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <EnableProguard>false</EnableProguard>
+    <AndroidSupportedAbis>armeabi-v7a:arm64-v8a</AndroidSupportedAbis>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />


### PR DESCRIPTION
Xamarin.Android will default to `armeabi-v7a:arm64-v8a` by default, but not sure when and where it will be available.
https://github.com/xamarin/xamarin-android/issues/1311

Also had to update the `TargetFrameworkVersion` to `v9.0` (pie) to be able to compile again.